### PR TITLE
Update README.md

### DIFF
--- a/3-photos/README.md
+++ b/3-photos/README.md
@@ -33,6 +33,7 @@ Run the following commands in the Cloud9 terminal to set environment variables u
 
 ```console
 AWS_REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
+FINAL_BUCKET=$(aws cloudformation describe-stack-resource --stack-name theme-park-backend --logical-resource-id FinalBucket --query "StackResourceDetail.PhysicalResourceId" --output text)
 accountId=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 s3_deploy_bucket="theme-park-sam-deploys-${accountId}"
 ```


### PR DESCRIPTION
Step 2-compositing will fail if $FINAL_BUCKET is not there. This is configured back in Step 1-app-deploy but will be lost if you fire up Cloud9 again on day 3 of the workshop.